### PR TITLE
Change the way to deal with the list of supported providers:

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -166,6 +166,7 @@
         <p>This API allows you to retrieve datasets or series in EViews from different SDMX providers.</p>
         <p>Currently, the app is supporting <strong>Insee</strong>, <strong>ECB</strong>, <strong>Eurostat</strong> & <strong>Worldbank</strong> data natively.</p>
         <p>Requests to <strong>Quandl</strong>, <strong>BLS</strong> and <strong>FRED</strong> are also supported.</p>
+        <p>The complete list of supported providers is available <a href="./providers">here</a>.</p>
         <p>Alternatively, SDMX requests to others providers can be made <a href="./form.html">here</a>.</p>
         <p>Some <a href="./slides.pdf">slides.</a></p>
       </div>

--- a/routes/buildHTML.js
+++ b/routes/buildHTML.js
@@ -303,3 +303,23 @@ exports.codeList = function (codes,title_dim) {
     return myHtml;
 };
 
+exports.listProviders = function(providers) {
+    var header = '<title> SDMX API for EViews / supported providers</title>',
+        css = '<style display:none>body {padding-left: 5%; padding-right: 5%; } </style>',
+        body = '<h2>Supported Providers</h2>',
+        theader = '<th>Id</th><th>Website</th><th style="text-align:center">SDMX</th><th style="text-align:center">API Key</th>',
+        tbody = '';
+    Object.keys(providers).forEach(function(item,index){
+        tbody += '<tr>';
+        tbody += '<td>' + item + '</td>';
+        tbody += '<td><a href="http://' + providers[item].host + '/">' + providers[item].host + '</a></td>';
+        if (providers[item].apiKey === 'True') {
+            tbody += '<td style="text-align:center">&#10006;</td><td style="text-align:center">&#10004;</td>';
+        } else {
+            tbody += '<td style="text-align:center">&#10004;</td><td style="text-align:center">&#10006;</td>';
+        }
+        tbody += '</tr>';
+    });
+    var myHtml = '<!DOCTYPE html>' + '<html><head>' + header + css + '</head><body>' + body + '<hr/><table class="table table-condensed table-hover">' + '<thead>'  + '<tr>' + theader + '</tr>' + '</thead>' + '<tbody class="list">' + tbody + '</tbody>'  +'</table></div>' + gA + jQuery + bootstrap +'</body></html>';
+    return myHtml;
+};

--- a/routes/fetcher.js
+++ b/routes/fetcher.js
@@ -20,7 +20,8 @@ var xml2js = require('xml2js'),
     url = require('url'),
     buildHTML = require('./buildHTML');
 
-const providers = ['INSEE','ECB','EUROSTAT','WITS','ILO'];
+const providers = require('./providers.json');
+
 
 // Utilitaries
 function stripPrefix(str){
@@ -43,122 +44,51 @@ function isInArray(it,arr) {
     return arr.indexOf(it) > -1;
 }
 
-// return the url "base" for a service Eurostat, BCE, INSEE
-function getService(service, callback) {
-
-    service = service.toUpperCase();
-    var url = '',
-        path = '',
-        provider = '';
-    if (service === "INSEE") {
-        url = 'www.bdm.insee.fr',
-        path = '/series/sdmx/',
-        provider = 'FR1';
-    } else if (service === "ECB") {
-        url = 'sdw-wsrest.ecb.europa.eu',
-        path = '/service/',
-        provider = 'ECB';
-    } else if (service === "EUROSTAT") {
-        url = 'ec.europa.eu',
-        path = '/eurostat/SDMX/diss-web/rest/',
-        provider = 'ESTAT';
-    } else if (service === 'WITS') {
-        url = 'wits.worldbank.org',
-        path = '/API/V1/SDMX/V21/rest/',
-        provider = 'WBG_WITS';
-    } else if (service === 'ILO') {
-        url = 'www.ilo.org';
-        path = '/ilostat/sdmx/ws/rest/';
-        provider = 'ILO';
-    }
-    callback([url,path,provider]);
-};
-
 // On récupére le nom de l'agence que l'on utilise pour récupérer la DSD d'un dataset
-function getAgency(service,dataset,callback) {
-    getService(service, function(url) {
-        var myPath = url[1]+'dataflow/'+url[2]+'/'+dataset + '?format=compact_2_1';
-        var options = {
-            hostname: url[0],
-            port: 80,
-            path: myPath,
-            headers: {
-                'connection' : 'keep-alive',
-                'accept': 'application/vnd.sdmx.structure+xml; version=2.1',
-                'user-agent': 'nodeJS'
-            }
-        };
-        http.get(options, function(result) {
-            if (result.statusCode >=200 && result.statusCode < 400) {
-                var xml = '';
-                result.on('data', function(chunk) {
-                    xml += chunk;
+function getAgency(provider,dataset,callback) {
+    var myPath = providers[provider.toUpperCase()].path + 'dataflow/' + providers[provider.toUpperCase()].agencyID +'/'+dataset + '?format=compact_2_1';
+    var options = {
+        hostname: providers[provider.toUpperCase()].host,
+        port: 80,
+        path: myPath,
+        headers: {
+            'connection' : 'keep-alive',
+            'accept': 'application/vnd.sdmx.structure+xml; version=2.1',
+            'user-agent': 'nodeJS'
+        }
+    };
+    http.get(options, function(result) {
+        if (result.statusCode >=200 && result.statusCode < 400) {
+            var xml = '';
+            result.on('data', function(chunk) {
+                xml += chunk;
+            });
+            result.on('end',function() {
+                xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
+                    if (err === null) {
+                        var agency = obj['Structure']['Structures'][0]['Dataflows'][0]['Dataflow'][0]['Structure']['0']['Ref'][0]['agencyID'],
+                            dsdId = obj['Structure']['Structures'][0]['Dataflows'][0]['Dataflow'][0]['Structure']['0']['Ref'][0]['id'];
+                        callback([agency,dsdId]);
+                    } else {
+                        callback([err]);
+                    };
                 });
-                result.on('end',function() {
-                    xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
-                        if (err === null) {
-                            var agency = obj['Structure']['Structures'][0]['Dataflows'][0]['Dataflow'][0]['Structure']['0']['Ref'][0]['agencyID'],
-                                dsdId = obj['Structure']['Structures'][0]['Dataflows'][0]['Dataflow'][0]['Structure']['0']['Ref'][0]['id'];
-                            callback([agency,dsdId]);
-                        } else {
-                            callback([err]);
-                        };
-                    });
-                });
-            }
-        });
+            });
+        }
     });
 };
 
 // Get dimension of the data using its datastructure
-function getDim(service, agency, dsdId, dataset, callback) {
+function getDim(provider, agency, dsdId, dataset, callback) {
     var nbDim = 0,
         arrDim = [];
-    getService(service, function(url) {
-        if ((agency === null && dsdId === null) && dataset !== null) {
-            getAgency(service,dataset,function(agencyInfo) {
-                agency = agencyInfo[0],
-                dsdId = agencyInfo[1];              
-                var myPath = url[1]+'datastructure/'+agency+'/'+dsdId + '?format=compact_2_1';
-                var options = {
-                    hostname: url[0],
-                    port: 80,
-                    path: myPath,
-                    headers: {
-                        'connection' : 'keep-alive',
-                        'accept': 'application/vnd.sdmx.structure+xml; version=2.1',
-                        'user-agent': 'nodeJS'
-                    }
-                };
-                // console.log(url[0]+myPath);
-                http.get(options, function(result) {
-                    if (result.statusCode >=200 && result.statusCode < 400) {
-                        var xml = '';
-                        result.on('data', function(chunk) {
-                            xml += chunk;
-                        });
-                        result.on('end',function() {
-                            xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
-                                if(err === null) {
-                                    var data = obj['Structure']['Structures'][0]['DataStructures'][0]['DataStructure'][0]['DataStructureComponents'][0]['DimensionList'][0]['Dimension'];
-                                    nbDim = data.length;
-                                    data.forEach(function(item,index) {
-                                        arrDim.push(item['id'][0]);
-                                    });
-                                    callback([nbDim,arrDim,data]); 
-                                }
-                            });
-                        });
-                    } 
-                });
-            });
-        } else if (agency === null && dataset === null) {
-            console.log("not possible not retrieve data with no agency nor dataset");
-        } else if (agency !== null && dsdId !== null) {
-
-            var myPath = url[1]+'datastructure/'+agency+'/'+dsdId + '?format=compact_2_1';
+    if ((agency === null && dsdId === null) && dataset !== null) {
+        getAgency(provider,dataset,function(agencyInfo) {
+            agency = agencyInfo[0],
+            dsdId = agencyInfo[1];              
+            var myPath = providers[provider.toUpperCase()].path + 'datastructure/'+agency+'/'+dsdId + '?format=compact_2_1';
             var options = {
-                hostname: url[0],
+                hostname: providers[provider.toUpperCase()].host,
                 port: 80,
                 path: myPath,
                 headers: {
@@ -186,67 +116,100 @@ function getDim(service, agency, dsdId, dataset, callback) {
                         });
                     });
                 } 
-            });           
-        }
-    });
+            });
+        });
+    } else if (agency === null && dataset === null) {
+        console.log("not possible not retrieve data with no agency nor dataset");
+    } else if (agency !== null && dsdId !== null) {
+
+        var myPath = providers[provider.toUpperCase()].path + 'datastructure/'+agency+'/'+dsdId + '?format=compact_2_1';
+        var options = {
+            hostname: providers[provider.toUpperCase()].host,
+            port: 80,
+            path: myPath,
+            headers: {
+                'connection' : 'keep-alive',
+                'accept': 'application/vnd.sdmx.structure+xml; version=2.1',
+                'user-agent': 'nodeJS'
+            }
+        };
+        http.get(options, function(result) {
+            if (result.statusCode >=200 && result.statusCode < 400) {
+                var xml = '';
+                result.on('data', function(chunk) {
+                    xml += chunk;
+                });
+                result.on('end',function() {
+                    xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
+                        if(err === null) {
+                            var data = obj['Structure']['Structures'][0]['DataStructures'][0]['DataStructure'][0]['DataStructureComponents'][0]['DimensionList'][0]['Dimension'];
+                            nbDim = data.length;
+                            data.forEach(function(item,index) {
+                                arrDim.push(item['id'][0]);
+                            });
+                            callback([nbDim,arrDim,data]); 
+                        }
+                    });
+                });
+            } 
+        });           
+    }
 };
 
+// ====================================== ROUTES ======================================
 
 // List the datasets of a provider
 exports.getAllDataFlow = function(req,res) {
-    var service = req.params.service;
-
-    if (isInArray(service.toUpperCase(),providers)) {
-        getService(service, function(url) {
-            var myPath = url[1]+'dataflow/'+url[2]+'/all?format=compact_2_1';
-            var options = {
-                hostname: url[0],
-                path: myPath,
-                headers: {
-                    'connection':'keep-alive',
-                    'accept': 'application/vnd.sdmx.structure+xml; version=2.1',
-                    'user-agent': 'nodeJS'
-                }
-            };
-            // console.log('http://'+url[0]+myPath);
-            http.get(options, function(result) {
-                if (result.statusCode >=200 && result.statusCode < 400) {
-                    var xml = '';
-                    result.on('data', function(chunk) {
-                        xml += chunk;
-                    });
-                    result.on('end',function() {
-                        xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
-                            if (err === null) {
-                                var data = [];
-                                try {
-                                    obj['Structure']['Structures'][0]['Dataflows'][0]['Dataflow'].forEach(function(it,ind){
-                                        var datasetId = it.id,
-                                            dsdId = it.Structure[0]['Ref'][0]['id'],
-                                            agency = it.Structure[0]['Ref'][0]['agencyID'],
-                                            name = it.Name;//[0]['_']
-                                        if (name.length > 1) {
-                                            name.forEach(function(item,index){
-                                                if (item['xml:lang'][0] === 'fr') {name = it.Name[index]['_'];}
-                                            });
-                                        } else {name = it.Name[0]['_'];}
-                                        data.push([datasetId,dsdId,agency,name,service]);
-                                    });
-                                    res.send(buildHTML.dataFlow(data,service));
-                                }
-                                catch(e) {
-                                    console.log(e);
-                                    res.status(500).send('COULD NOT PARSE SDMX ANSWER');
-                                }
-                            } else {
-                                res.send(err);
+    var provider = req.params.provider;
+    if (isInArray(provider.toUpperCase(),Object.keys(providers))) {
+        var myPath = providers[provider.toUpperCase()].path+'dataflow/'+providers[provider.toUpperCase()].agencyID+'/all?format=compact_2_1';
+        var options = {
+            hostname: providers[provider.toUpperCase()].host,
+            path: myPath,
+            headers: {
+                'connection':'keep-alive',
+                'accept': 'application/vnd.sdmx.structure+xml; version=2.1',
+                'user-agent': 'nodeJS'
+            }
+        };
+        // console.log('http://'+url[0]+myPath);
+        http.get(options, function(result) {
+            if (result.statusCode >=200 && result.statusCode < 400) {
+                var xml = '';
+                result.on('data', function(chunk) {
+                    xml += chunk;
+                });
+                result.on('end',function() {
+                    xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
+                        if (err === null) {
+                            var data = [];
+                            try {
+                                obj['Structure']['Structures'][0]['Dataflows'][0]['Dataflow'].forEach(function(it,ind){
+                                    var datasetId = it.id,
+                                        dsdId = it.Structure[0]['Ref'][0]['id'],
+                                        agency = it.Structure[0]['Ref'][0]['agencyID'],
+                                        name = it.Name;//[0]['_']
+                                    if (name.length > 1) {
+                                        name.forEach(function(item,index){
+                                            if (item['xml:lang'][0] === 'fr') {name = it.Name[index]['_'];}
+                                        });
+                                    } else {name = it.Name[0]['_'];}
+                                    data.push([datasetId,dsdId,agency,name,provider]);
+                                });
+                                res.send(buildHTML.dataFlow(data,provider));
                             }
-                        });
+                            catch(e) {
+                                console.log(e);
+                                res.status(500).send('COULD NOT PARSE SDMX ANSWER');
+                            }
+                        } else {
+                            res.send(err);
+                        }
                     });
-                } else {
-                    res.send(result.statusCode);
-                }
-            });
+                });
+            } else {
+                res.send(result.statusCode);
+            }
         });
     } else {
         res.status(404).send('ERROR 404 - PROVIDER IS NOT SUPPORTED.');
@@ -258,7 +221,7 @@ exports.getAllDataFlow = function(req,res) {
 // List the timeseries inside a dataset
 
 exports.getDataFlow = function(req,res) {
-    var service = req.params.service,
+    var provider = req.params.provider,
         dataSet = req.params.dataset,
         myTimeout = req.query.timeout;
 
@@ -267,72 +230,69 @@ exports.getDataFlow = function(req,res) {
     } else {
         myTimeout = +myTimeout;
     }
-    if (isInArray(service.toUpperCase(),providers)) {
-        getDim(service,null,null,dataSet,function(arr) {
-            getService(service, function(url) {
-                var myPath = url[1]+'data/'+dataSet+'?detail=nodata&format=compact_2_1';
-                var options = {
-                    hostname : url[0],
-                    port: 80,
-                    path: myPath,
-                    headers: {
-                        'connection': 'keep-alive',
-                        'accept': 'application/vnd.sdmx.structurespecificdata+xml;version=2.1',
-                        'user-agent': 'nodeJS'
-                    }
-                };
-                var request = http.get(options, function(result) {
-                    if (result.statusCode >= 200 && result.statusCode < 400) {
-                        var xml = '';
-                        result.on('data', function(chunk) { xml += chunk;});
-                        result.on('end',function() {
-                            xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj) {
-                                if (err === null) {
-                                    var footer =  obj.StructureSpecificData.Footer;
-                                    try { footer = footer[0].Message[0].code[0];}
-                                    catch(e) {}
-                                    finally {
-                                        if (footer == '413') {
-                                            var errorFooter413 = '413 | Dataset is too big to retreive'; // Eurostat is sending error 413 in the footer...
-                                            res.send(buildHTML.detailDataset(service,null,dataSet,arr,errorFooter413));
-                                        } else if (footer != null) {
-                                            res.status(footer).send('ERROR | Code : '+ footer + ' ' + getErrorMessage(footer));
-                                        } else {                   
-                                            var data = obj.StructureSpecificData.DataSet[0];
-                                            var vTS = data.Series;
-                                            if (!res.headersSent) {
-                                                res.send(buildHTML.detailDataset(service,vTS,dataSet,arr,null));
-                                            };}}}
-                                else {
-                                    res.send(err);
-                                }
-                            });
+    if (isInArray(provider.toUpperCase(),Object.keys(providers))) {
+        getDim(provider,null,null,dataSet,function(arr) {
+            var myPath = providers[provider.toUpperCase()].path+'data/'+dataSet+'?detail=nodata&format=compact_2_1';
+            var options = {
+                hostname : providers[provider.toUpperCase()].host,
+                port: 80,
+                path: myPath,
+                headers: {
+                    'connection': 'keep-alive',
+                    'accept': 'application/vnd.sdmx.structurespecificdata+xml;version=2.1',
+                    'user-agent': 'nodeJS'
+                }
+            };
+            var request = http.get(options, function(result) {
+                if (result.statusCode >= 200 && result.statusCode < 400) {
+                    var xml = '';
+                    result.on('data', function(chunk) { xml += chunk;});
+                    result.on('end',function() {
+                        xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj) {
+                            if (err === null) {
+                                var footer =  obj.StructureSpecificData.Footer;
+                                try { footer = footer[0].Message[0].code[0];}
+                                catch(e) {}
+                                finally {
+                                    if (footer == '413') {
+                                        var errorFooter413 = '413 | Dataset is too big to retreive'; // Eurostat is sending error 413 in the footer...
+                                        res.send(buildHTML.detailDataset(provider,null,dataSet,arr,errorFooter413));
+                                    } else if (footer != null) {
+                                        res.status(footer).send('ERROR | Code : '+ footer + ' ' + getErrorMessage(footer));
+                                    } else {                   
+                                        var data = obj.StructureSpecificData.DataSet[0];
+                                        var vTS = data.Series;
+                                        if (!res.headersSent) {
+                                            res.send(buildHTML.detailDataset(provider,vTS,dataSet,arr,null));
+                                        };}}}
+                            else {
+                                res.send(err);
+                            }
                         });
-                    } else {
-                        if (!res.headersSent) {
-                            var error = result.statusMessage;
-                            res.send(buildHTML.detailDataset(service,null,dataSet,arr,error));
-                        }
-                    }
-                });
-                request.setTimeout(myTimeout,function() {
-                    var errorDatasetTooBig = 'the dataset is too big to retrieve all the timeseries. You can increase timeout by adding "?timeout=" at the end of the url (default is 5000ms)';
+                    });
+                } else {
                     if (!res.headersSent) {
-                        res.send(buildHTML.detailDataset(service,null,dataSet,arr,errorDatasetTooBig));
+                        var error = result.statusMessage;
+                        res.send(buildHTML.detailDataset(provider,null,dataSet,arr,error));
                     }
-                });
+                }
+            });
+            request.setTimeout(myTimeout,function() {
+                var errorDatasetTooBig = 'the dataset is too big to retrieve all the timeseries. You can increase timeout by adding "?timeout=" at the end of the url (default is 5000ms)';
+                if (!res.headersSent) {
+                    res.send(buildHTML.detailDataset(provider,null,dataSet,arr,errorDatasetTooBig));
+                }
             });
         });
-    } else {res.status(404).send('ERROR 404 - SERVICE IS NOT SUPPORTED');}
+    } else {res.status(404).send('ERROR 404 - PROVIDER IS NOT SUPPORTED');}
 };
 
 // Download a Dataset
 exports.getDataSet = function(req,res) {
-
-    var service = req.params.service.toUpperCase();
-    if (isInArray(service,providers)) {
+    var provider = req.params.provider.toUpperCase();
+    if (isInArray(provider,Object.keys(providers))) {
         var dataSet = '';
-        if (service !== 'EUROSTAT')  {
+        if (provider !== 'EUROSTAT')  {
             dataSet = req.params.dataset.toUpperCase();
         } else {
             dataSet = req.params.dataset;        
@@ -352,90 +312,87 @@ exports.getDataSet = function(req,res) {
             else if (key === 'endPeriod') {reqParams[key] = req.query[key];}
             else {reqParams[key.toUpperCase()] = req.query[kkey];}
         }      
-        var userParams = '';
-        
-        getService(service, function(url) {
-            var myPath = url[1]+'data/'+dataSet;
-            getDim(service, null, null, dataSet, function(arr) {
-                var authParams = arr[1]; // Authorised Parameters.
-                var compt = 0;
-                authParams.forEach(function(it,ind){
-                    if(reqParams[it] != null) {
-                        if(ind<arr[0]-1) {userParams += reqParams[it]+'.';}
-                        else { userParams += reqParams[it];}
-                        delete reqParams[it];}
-                    else {
-                        if (ind<arr[0]-1) {
-                            userParams += '.';
-                        }
-                        compt ++;
+        var userParams = '';        
+        var myPath = providers[provider].path + 'data/' + dataSet;
+        getDim(provider, null, null, dataSet, function(arr) {
+            var authParams = arr[1]; // Authorised Parameters.
+            var compt = 0;
+            authParams.forEach(function(it,ind){
+                if(reqParams[it] != null) {
+                    if(ind<arr[0]-1) {userParams += reqParams[it]+'.';}
+                    else { userParams += reqParams[it];}
+                    delete reqParams[it];}
+                else {
+                    if (ind<arr[0]-1) {
+                        userParams += '.';
                     }
-                });
-                // When the whole dataSet is requested.
-                if (compt == arr[0]) {
-                    userParams = '';
-                };
-                myPath += '/' + userParams + '?';
-                Object.keys(reqParams).forEach(function(it,ind,arr) {
-                    myPath += it.toString() + "=" + reqParams[it] ;
-                    if (ind < arr.length-1) {
-                        myPath += "&";
-                    }
-                });
-                var options = {
-                    hostname: url[0],
-                    port: 80,
-                    path: myPath,
-                    headers: {
-                        'connection': 'keep-alive',
-                        'accept': 'application/vnd.sdmx.structurespecificdata+xml;version=2.1',
-                        'user-agent': 'nodeJS'
-                    }
-                };
-                http.get(options, function(result) {
-                    if (result.statusCode >= 200 && result.statusCode < 400) {
-                        var xml = '';
-                        result.on('data', function(chunk) {xml += chunk;});
-                        result.on('end',function() {
-                            xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
-                                if(err === null) {
-                                    try {
-                                        var data = obj.StructureSpecificData.DataSet[0];
-                                        var vTS = data.Series;
-                                        if (!req.timedout) {
-                                            res.send(buildHTML.makeTable(vTS,dataSet,authParams));
-                                        }
-                                    } catch(e) {
-                                        if (obj.StructureSpecificData.Footer[0].Message[0].code[0] === '413') {
-                                            res.redirect('/413.html');
-                                        } else {
-                                            res.set('Content-Type','text/plain');
-                                            res.statusCode(500).send('ERROR PARSER SDMX');
-                                        }
+                    compt ++;
+                }
+            });
+            // When the whole dataSet is requested.
+            if (compt == arr[0]) {
+                userParams = '';
+            };
+            myPath += '/' + userParams + '?';
+            Object.keys(reqParams).forEach(function(it,ind,arr) {
+                myPath += it.toString() + "=" + reqParams[it] ;
+                if (ind < arr.length-1) {
+                    myPath += "&";
+                }
+            });
+            var options = {
+                hostname: providers[provider.toUpperCase()].host,
+                port: 80,
+                path: myPath,
+                headers: {
+                    'connection': 'keep-alive',
+                    'accept': 'application/vnd.sdmx.structurespecificdata+xml;version=2.1',
+                    'user-agent': 'nodeJS'
+                }
+            };
+            http.get(options, function(result) {
+                if (result.statusCode >= 200 && result.statusCode < 400) {
+                    var xml = '';
+                    result.on('data', function(chunk) {xml += chunk;});
+                    result.on('end',function() {
+                        xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
+                            if(err === null) {
+                                try {
+                                    var data = obj.StructureSpecificData.DataSet[0];
+                                    var vTS = data.Series;
+                                    if (!req.timedout) {
+                                        res.send(buildHTML.makeTable(vTS,dataSet,authParams));
                                     }
-                                } else {
-                                    res.send(err);
+                                } catch(e) {
+                                    if (obj.StructureSpecificData.Footer[0].Message[0].code[0] === '413') {
+                                        res.redirect('/413.html');
+                                    } else {
+                                        res.set('Content-Type','text/plain');
+                                        res.statusCode(500).send('ERROR PARSER SDMX');
+                                    }
                                 }
-                            });
+                            } else {
+                                res.send(err);
+                            }
                         });
-                    } else if (result.statusCode === 413) {
-                            res.redirect('/413.html');
-                    } else {
-                        res.status(result.statusCode).send(result.statusMessage);
-                    }
-                });
+                    });
+                } else if (result.statusCode === 413) {
+                    res.redirect('/413.html');
+                } else {
+                    res.status(result.statusCode).send(result.statusMessage);
+                }
             });
         });
     } else {
-        res.status(404).send("ERROR 404 - SERVICE IS NOT SUPPORTED");
+        res.status(404).send("ERROR 404 - PROVIDER IS NOT SUPPORTED");
     }
 };
 
 exports.getSeries = function(req,res) {
 
     var series = req.params.series,
-        service = req.params.service.toUpperCase();
-    if (isInArray(service,providers)) {
+        provider = req.params.provider.toUpperCase();
+    if (isInArray(provider,Object.keys(providers))) {
         var keys = Object.keys(req.query);
         var params = "?";
         keys.forEach(function(it,ind,arr) {
@@ -446,7 +403,7 @@ exports.getSeries = function(req,res) {
         });
         if (keys.length > 0) {params += '&format=compact_2_1';}
         else { params += '&format=compact_2_1';}
-        if (service == "INSEE") {
+        if (provider == "INSEE") {
             var myPath = '/series/sdmx/data/SERIES_BDM/'+series+params;
             var options = {
                 hostname: 'www.bdm.insee.fr',
@@ -488,78 +445,28 @@ exports.getSeries = function(req,res) {
                 dataSet = arr[0];
             arr.shift();
             var userParams = arr.join('.');
-            getService(service, function(url) {
-                var myPath = url[1]+'data/'+dataSet+'/'+userParams + params;
-                var options = {
-                    hostname: url[0],
-                    port: 80,
-                    path: myPath,
-                    headers: {
-                        'connection': 'keep-alive',
-                        'accept': 'application/vnd.sdmx.structurespecificdata+xml;version=2.1',
-                        'user-agent': 'nodeJS'
-                    }
-                };
-                http.get(options, function(result) {
-                    if (result.statusCode >= 200 && result.statusCode < 400) {
-                        var xml = '';
-                        result.on('data', function(chunk) {xml += chunk;});
-                        result.on('end',function() {
-                            xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
-                                if(err === null) {
-                                    var data = obj.StructureSpecificData.DataSet[0];
-                                    var vTS = data.Series;
-                                    if (!req.timedout) {
-                                        res.send(buildHTML.makeTable(vTS,series,[]));
-                                    }
-                                } else {
-                                    res.send(err);
-                                }
-                            });
-                        });
-                    } else {
-                        res.status(result.statusCode).send(result.statusMessage);
-                    }
-                });
-            });
-        };
-    } else {
-        res.status(404).send('ERROR 404 - SERVICE IS NOT SUPPORTED');
-    }
-};
-
-exports.getCodeList = function(req,res) {
-
-    var service = req.params.service,
-        dim = req.params.codelist;
-
-    if (isInArray(service.toUpperCase(),providers)) {    
-        getService(service,function(url) {
-            var myPath = url[1]+'codelist/'+url[2]+ '/' + dim + '?format=compact_2_1';
+            var myPath = providers[provider].path+'data/'+dataSet+'/'+userParams + params;
             var options = {
-                hostname: url[0],
+                hostname: providers[provider].host,
                 port: 80,
                 path: myPath,
                 headers: {
                     'connection': 'keep-alive',
-                    'accept': 'application/vnd.sdmx.structure+xml; version=2.1',
+                    'accept': 'application/vnd.sdmx.structurespecificdata+xml;version=2.1',
                     'user-agent': 'nodeJS'
                 }
             };
             http.get(options, function(result) {
-                if (result.statusCode >=200 && result.statusCode < 400) {
+                if (result.statusCode >= 200 && result.statusCode < 400) {
                     var xml = '';
                     result.on('data', function(chunk) {xml += chunk;});
                     result.on('end',function() {
                         xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
                             if(err === null) {
-                                try {
-                                    var data = obj['Structure']['Structures'][0]['Codelists'][0]['Codelist'][0];
-                                    var title_dim = data['id'][0];
-                                    var codes = data['Code'];
-                                    res.send(buildHTML.codeList(codes,title_dim));}
-                                catch(e) {
-                                    res.status(500).set('Content-Type','text/plain').send('COULD NOT PARSE SDMX');
+                                var data = obj.StructureSpecificData.DataSet[0];
+                                var vTS = data.Series;
+                                if (!req.timedout) {
+                                    res.send(buildHTML.makeTable(vTS,series,[]));
                                 }
                             } else {
                                 res.send(err);
@@ -569,10 +476,56 @@ exports.getCodeList = function(req,res) {
                 } else {
                     res.status(result.statusCode).send(result.statusMessage);
                 }
-            });                   
-        });
+            });
+        };
     } else {
-        res.status(404).send('ERROR 404 - SERVICE IS NOT SUPPORTED');
+        res.status(404).send('ERROR 404 - PROVIDER IS NOT SUPPORTED');
+    }
+};
+
+exports.getCodeList = function(req,res) {
+
+    var provider = req.params.provider,
+        dim = req.params.codelist;
+
+    if (isInArray(provider.toUpperCase(),Object.keys(providers))) {    
+        var myPath = providers[provider].path+'codelist/' + providers[provider].agencyID + '/' + dim + '?format=compact_2_1';
+        var options = {
+            hostname: providers[provider].host,
+            port: 80,
+            path: myPath,
+            headers: {
+                'connection': 'keep-alive',
+                'accept': 'application/vnd.sdmx.structure+xml; version=2.1',
+                'user-agent': 'nodeJS'
+            }
+        };
+        http.get(options, function(result) {
+            if (result.statusCode >=200 && result.statusCode < 400) {
+                var xml = '';
+                result.on('data', function(chunk) {xml += chunk;});
+                result.on('end',function() {
+                    xml2js.parseString(xml, {tagNameProcessors: [stripPrefix], mergeAttrs : true}, function(err,obj){
+                        if(err === null) {
+                            try {
+                                var data = obj['Structure']['Structures'][0]['Codelists'][0]['Codelist'][0];
+                                var title_dim = data['id'][0];
+                                var codes = data['Code'];
+                                res.send(buildHTML.codeList(codes,title_dim));}
+                            catch(e) {
+                                res.status(500).set('Content-Type','text/plain').send('COULD NOT PARSE SDMX');
+                            }
+                        } else {
+                            res.send(err);
+                        }
+                    });
+                });
+            } else {
+                res.status(result.statusCode).send(result.statusMessage);
+            }
+        });                   
+    } else {
+        res.status(404).send('ERROR 404 - PROVIDER IS NOT SUPPORTED');
     }
 };
 
@@ -668,4 +621,8 @@ exports.redirectURL = function(req,res) {
     var myUrl = req.body.myUrl;
     var route = "/req?url='" + myUrl + "'";
     res.redirect(route);
+};
+
+exports.getProviders = function(req,res) {
+    res.send(buildHTML.listProviders(providers));
 };

--- a/routes/providers.json
+++ b/routes/providers.json
@@ -1,0 +1,50 @@
+{
+    "INSEE": {
+        "host": "www.bdm.insee.fr",
+        "path": "/series/sdmx/",
+        "agencyID": "FR1",
+        "apiKey": "False"
+    },
+    "EUROSTAT": {
+        "host": "ec.europa.eu",
+        "path": "/eurostat/SDMX/diss-web/rest/",
+        "agencyID": "ESTAT",
+        "apiKey": "False"
+    },
+    "ECB": {
+        "host": "sdw-wsrest.ecb.europa.eu",
+        "path": "/service/",
+        "agencyID": "ECB",
+        "apiKey": "False"
+    },
+    "WITS": {
+        "host": "wits.worldbank.org",
+        "path": "/API/V1/SDMX/V21/rest/",
+        "agencyID": "WBG_WITS",
+        "apiKey": "False"
+    },
+    "ILO": {
+        "host": "www.ilo.org",
+        "path": "/ilostat/sdmx/ws/rest/",
+        "agencyID": "ILO",
+        "apiKey": "False"
+    },
+    "Quandl": {
+        "host": "www.quandl.com",
+        "path": "",
+        "agencyID": "",
+        "apiKey": "True"
+    },
+    "Fred": {
+        "host": "api.stlouisfed.org",
+        "path": "",
+        "agencyID": "",
+        "apiKey": "True"
+    },
+    "BLS": {
+        "host": "api.bls.gov",
+        "path": "",
+        "agencyID": "",
+        "apiKey": "True"
+    }
+}

--- a/server.js
+++ b/server.js
@@ -44,11 +44,12 @@ app.use(timeout(29900,{"respond":true}));
 // SDMX PROVIDER
 // -----------------------
 // Timeseries from supported providers
-app.get('/:service/dataflow', fetcher.getAllDataFlow);
-app.get('/:service/dataflow/:dataset', fetcher.getDataFlow);
-app.get('/:service/dataset/:dataset',fetcher.getDataSet);
-app.get('/:service/series/:series',fetcher.getSeries);
-app.get('/:service/codelist/:codelist',fetcher.getCodeList);
+app.get('/:provider/dataflow', fetcher.getAllDataFlow);
+app.get('/:provider/dataflow/:dataset', fetcher.getDataFlow);
+app.get('/:provider/dataset/:dataset',fetcher.getDataSet);
+app.get('/:provider/series/:series',fetcher.getSeries);
+app.get('/:provider/codelist/:codelist',fetcher.getCodeList);
+app.get('/providers',fetcher.getProviders);
 
 // Timeseries from sdmx url
 app.get('/req',fetcher.getDatafromURL);


### PR DESCRIPTION
Hey @Asigwalt, peux-tu jeter un oeil à mon commit ?

Main changes :
+ The list of supported providers is in a separated JSON file.
+ The JSON file contains hostname, path and agencyID. The JSON file is loaded by fetcher.js
+ The getService function is not necessary anymore.
+ The word 'service' has been replace by 'provider' everywhere in the code since it seems more intuitive and in line with SDMX.
