### PR TITLE
Add support for codelist

### DIFF
--- a/routes/buildHTML.js
+++ b/routes/buildHTML.js
@@ -227,7 +227,7 @@ exports.detailDataset = function(service,vTS,dataSet,arr,errorDatasetTooBig) {
     arr[2].forEach(function(it,ind) {
         var code = it['LocalRepresentation'][0]['Enumeration'][0]['Ref'][0]['id'][0],
             nomDim = it['id'][0];
-        body += '<li><a href=/'+ service + '/codelist/' + code + '>' + nomDim + '</a></li>';
+        body += '<li><a href=/'+ service + '/codelist/' + code + '?dsdId=' + arr[3] +'>' + nomDim + '</a></li>';
     });
     body += '</ul>';
     body += '<h3> 2. List of the timeseries contained in the dataset</h3>';


### PR DESCRIPTION
Hello @Asigwalt et @psabalot,

J'ai ajouté la possibilité de voir la liste des codes pour une dimension donnée (exemple voir M,Q pour la dimension `frequency`) pour le provider **Eurostat**.

Eurostat, contrairement aux autres providers, n'accepte pas les requêtes `codelist` mais on trouve la liste des codes pour un dataset donné dans la Datastructure.
Du coup, j'ai modifié le code pour les récupérer là quand le provider est Eurostat.
Quand vous êtes ok, vous pouvez merger.

Cheers,

Louis